### PR TITLE
Capture and apply 'Reply-to' Header

### DIFF
--- a/lib/bamboo/adapters/ses_adapter.ex
+++ b/lib/bamboo/adapters/ses_adapter.ex
@@ -24,6 +24,7 @@ defmodule Bamboo.SesAdapter do
     message =
       Mail.build_multipart()
       |> Mail.put_from(prepare_address(email.from))
+      |> Mail.put_reply_to(email.headers["Reply-To"])
       |> Mail.put_to(prepare_addresses(email.to))
       |> Mail.put_cc(prepare_addresses(email.cc))
       |> Mail.put_bcc(prepare_addresses(email.bcc))

--- a/test/lib/bamboo/adapters/ses_adapter_test.exs
+++ b/test/lib/bamboo/adapters/ses_adapter_test.exs
@@ -13,6 +13,7 @@ defmodule Bamboo.SesAdapterTest do
       cc: "john@example.com",
       bcc: "jane@example.com",
       subject: "Welcome to the app.",
+      headers: %{"Reply-To" => "chuck@example.com"},
       html_body: "<strong>Thanks for joining!</strong>",
       text_body: "Thanks for joining!"
     ) |> Mailer.normalize_addresses()
@@ -38,6 +39,7 @@ defmodule Bamboo.SesAdapterTest do
       message = parse_body(body)
       assert Mail.get_from(message) == "bob@example.com"
       assert Mail.get_to(message) == ["alice@example.com"]
+      assert Mail.get_reply_to(message) == "chuck@example.com"
       assert Mail.get_cc(message) == "john@example.com"
       assert Mail.get_subject(message) == "Welcome to the app."
       assert Mail.get_text(message).body == "Thanks for joining!"


### PR DESCRIPTION
I wasn't able to set the `Reply-To` header using the example provided in the base Bamboo docs. Once I added the `Mail.put_reply_to` line in, it started working.

Let me know if I need to change something to line up with the way you would prefer it to operate.