### PR TITLE
Add ex_aws config to enable overrides ExAws config

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,7 @@ AWS SES adapter for Bamboo
 
 ## Installation
 
-If [available in Hex](https://hex.pm/docs/publish), the package can be installed
-by adding `bamboo_ses` to your list of dependencies in `mix.exs`:
+The package can be installed by adding `bamboo_ses` to your list of dependencies in `mix.exs`:
 
 ```elixir
 def deps do
@@ -21,13 +20,22 @@ end
 
 Change the config for your mailer:
 
-    config :my_app, MyApp.Mailer,
-      adapter: Bamboo.SesAdapter
+```elixir
+config :my_app, MyApp.Mailer,
+  adapter: Bamboo.SesAdapter
+```
 
-To find more on AWS key configuration please follow [this link](https://github.com/ex-aws/ex_aws#aws-key-configuration)
+This package has [ExAws](https://github.com/ex-aws/ex_aws) as a dependency, and you have to configure it. To find more
+on AWS key configuration, please follow [this link](https://github.com/ex-aws/ex_aws#aws-key-configuration).
+
+You can also override the default ExAws configuration defining a Keyword list as `ex_aws` key in the mailer config:
+
+```elixir
+config :my_app, MyApp.Mailer,
+  adapter: Bamboo.SesAdapter,
+  ex_aws: [region: "eu-west-1"]
+```
 
 ## Documentation
 
-Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
-and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
-be found at [https://hexdocs.pm/bamboo_ses](https://hexdocs.pm/bamboo_ses).
+Documentation can be found at [https://hexdocs.pm/bamboo_ses](https://hexdocs.pm/bamboo_ses).

--- a/lib/bamboo/adapters/rfc2822_with_bcc.ex
+++ b/lib/bamboo/adapters/rfc2822_with_bcc.ex
@@ -42,6 +42,7 @@ defmodule Bamboo.SesAdapter.RFC2822WithBcc do
   individual part
   """
   def render_part(message, render_part_function \\ &render_part/1)
+
   def render_part(%Message{multipart: true} = message, fun) do
     boundary = Message.get_boundary(message)
     message = Message.put_boundary(message, boundary)
@@ -49,12 +50,14 @@ defmodule Bamboo.SesAdapter.RFC2822WithBcc do
     headers = render_headers(message.headers)
     boundary = "--#{boundary}"
 
-    parts = message.parts
-            |> render_parts(fun)
-            |> Enum.join("\r\n\r\n#{boundary}\r\n")
+    parts =
+      message.parts
+      |> render_parts(fun)
+      |> Enum.join("\r\n\r\n#{boundary}\r\n")
 
     "#{headers}\r\n\r\n#{boundary}\r\n#{parts}\r\n#{boundary}--"
   end
+
   def render_part(%Message{} = message, _fun) do
     encoded_body = encode(message.body, message)
     "#{render_headers(message.headers)}\r\n\r\n#{encoded_body}"
@@ -67,8 +70,10 @@ defmodule Bamboo.SesAdapter.RFC2822WithBcc do
   Will render a given header according to the RFC2882 spec
   """
   def render_header(key, value)
+
   def render_header(key, value) when is_atom(key),
     do: render_header(Atom.to_string(key), value)
+
   def render_header(key, value) do
     key =
       key
@@ -82,10 +87,14 @@ defmodule Bamboo.SesAdapter.RFC2822WithBcc do
 
   defp render_header_value("Date", date_time),
     do: timestamp_from_erl(date_time)
-  defp render_header_value(address_type, addresses) when is_list(addresses) and address_type in @address_types,
-    do: addresses |> Enum.map(&render_address(&1)) |> Enum.join(", ")
+
+  defp render_header_value(address_type, addresses)
+       when is_list(addresses) and address_type in @address_types,
+       do: addresses |> Enum.map(&render_address(&1)) |> Enum.join(", ")
+
   defp render_header_value(address_type, address) when address_type in @address_types,
     do: render_address(address)
+
   defp render_header_value("Content-Transfer-Encoding" = key, value) when is_atom(value) do
     value =
       value
@@ -97,28 +106,34 @@ defmodule Bamboo.SesAdapter.RFC2822WithBcc do
 
   defp render_header_value(_key, [value | subtypes]),
     do: Enum.join([value | render_subtypes(subtypes)], "; ")
+
   defp render_header_value(key, value),
     do: render_header_value(key, List.wrap(value))
 
   defp validate_address(address) do
     case Regex.match?(@email_validation_regex, address) do
-      true -> address
-      false -> raise ArgumentError,
-        message: """
-        The email address `#{address}` is invalid.
-        """
+      true ->
+        address
+
+      false ->
+        raise ArgumentError,
+          message: """
+          The email address `#{address}` is invalid.
+          """
     end
   end
 
   defp render_address({name, email}), do: ~s("#{name}" <#{validate_address(email)}>)
   defp render_address(email), do: validate_address(email)
   defp render_subtypes([]), do: []
+
   defp render_subtypes([{key, value} | subtypes]) when is_atom(key),
     do: render_subtypes([{Atom.to_string(key), value} | subtypes])
 
   defp render_subtypes([{"boundary", value} | subtypes]) do
     [~s(boundary="#{value}") | render_subtypes(subtypes)]
   end
+
   defp render_subtypes([{key, value} | subtypes]) do
     key = String.replace(key, "_", "-")
     ["#{key}=#{value}" | render_subtypes(subtypes)]
@@ -128,8 +143,10 @@ defmodule Bamboo.SesAdapter.RFC2822WithBcc do
   Will render all headers according to the RFC2882 spec
   """
   def render_headers(headers)
+
   def render_headers(map) when is_map(map),
-    do: map |> Map.to_list |> render_headers()
+    do: map |> Map.to_list() |> render_headers()
+
   def render_headers(list) when is_list(list) do
     list
     |> do_render_headers()
@@ -155,13 +172,15 @@ defmodule Bamboo.SesAdapter.RFC2822WithBcc do
   end
 
   defp pad(num),
-    do: num
-        |> Integer.to_string()
-        |> String.pad_leading(2, "0")
+    do:
+      num
+      |> Integer.to_string()
+      |> String.pad_leading(2, "0")
 
   defp do_render_headers([]), do: []
   defp do_render_headers([{_key, nil} | headers]), do: do_render_headers(headers)
   defp do_render_headers([{_key, []} | headers]), do: do_render_headers(headers)
+
   defp do_render_headers([{key, value} | headers]) when is_binary(value) do
     if String.trim(value) == "" do
       do_render_headers(headers)
@@ -169,6 +188,7 @@ defmodule Bamboo.SesAdapter.RFC2822WithBcc do
       [render_header(key, value) | do_render_headers(headers)]
     end
   end
+
   defp do_render_headers([{key, value} | headers]) do
     [render_header(key, value) | do_render_headers(headers)]
   end
@@ -179,7 +199,7 @@ defmodule Bamboo.SesAdapter.RFC2822WithBcc do
     if Message.has_attachment?(message) do
       text_parts =
         message.parts
-        |> Enum.filter(&(match_content_type?(&1, ~r/text\/(plain|html)/)))
+        |> Enum.filter(&match_content_type?(&1, ~r/text\/(plain|html)/))
         |> Enum.sort(&(&1 > &2))
 
       content_type = List.replace_at(content_type, 0, "multipart/mixed")
@@ -188,14 +208,16 @@ defmodule Bamboo.SesAdapter.RFC2822WithBcc do
       if Enum.any?(text_parts) do
         message =
           text_parts
-          |> Enum.reduce(message, &(Message.delete_part(&2, &1)))
+          |> Enum.reduce(message, &Message.delete_part(&2, &1))
+
         mixed_part =
           Mail.build_multipart()
           |> Message.put_content_type("multipart/alternative")
 
         mixed_part =
           text_parts
-          |> Enum.reduce(mixed_part, &(Message.put_part(&2, &1)))
+          |> Enum.reduce(mixed_part, &Message.put_part(&2, &1))
+
         put_in(message.parts, List.insert_at(message.parts, 0, mixed_part))
       end
     else
@@ -203,6 +225,7 @@ defmodule Bamboo.SesAdapter.RFC2822WithBcc do
       Message.put_content_type(message, content_type)
     end
   end
+
   defp reorganize(%Message{} = message), do: message
 
   defp encode(body, message) do

--- a/lib/bamboo/adapters/rfc2822_with_bcc.ex
+++ b/lib/bamboo/adapters/rfc2822_with_bcc.ex
@@ -42,7 +42,6 @@ defmodule Bamboo.SesAdapter.RFC2822WithBcc do
   individual part
   """
   def render_part(message, render_part_function \\ &render_part/1)
-
   def render_part(%Message{multipart: true} = message, fun) do
     boundary = Message.get_boundary(message)
     message = Message.put_boundary(message, boundary)
@@ -50,14 +49,12 @@ defmodule Bamboo.SesAdapter.RFC2822WithBcc do
     headers = render_headers(message.headers)
     boundary = "--#{boundary}"
 
-    parts =
-      message.parts
-      |> render_parts(fun)
-      |> Enum.join("\r\n\r\n#{boundary}\r\n")
+    parts = message.parts
+            |> render_parts(fun)
+            |> Enum.join("\r\n\r\n#{boundary}\r\n")
 
     "#{headers}\r\n\r\n#{boundary}\r\n#{parts}\r\n#{boundary}--"
   end
-
   def render_part(%Message{} = message, _fun) do
     encoded_body = encode(message.body, message)
     "#{render_headers(message.headers)}\r\n\r\n#{encoded_body}"
@@ -70,10 +67,8 @@ defmodule Bamboo.SesAdapter.RFC2822WithBcc do
   Will render a given header according to the RFC2882 spec
   """
   def render_header(key, value)
-
   def render_header(key, value) when is_atom(key),
     do: render_header(Atom.to_string(key), value)
-
   def render_header(key, value) do
     key =
       key
@@ -87,14 +82,10 @@ defmodule Bamboo.SesAdapter.RFC2822WithBcc do
 
   defp render_header_value("Date", date_time),
     do: timestamp_from_erl(date_time)
-
-  defp render_header_value(address_type, addresses)
-       when is_list(addresses) and address_type in @address_types,
-       do: addresses |> Enum.map(&render_address(&1)) |> Enum.join(", ")
-
+  defp render_header_value(address_type, addresses) when is_list(addresses) and address_type in @address_types,
+    do: addresses |> Enum.map(&render_address(&1)) |> Enum.join(", ")
   defp render_header_value(address_type, address) when address_type in @address_types,
     do: render_address(address)
-
   defp render_header_value("Content-Transfer-Encoding" = key, value) when is_atom(value) do
     value =
       value
@@ -106,34 +97,28 @@ defmodule Bamboo.SesAdapter.RFC2822WithBcc do
 
   defp render_header_value(_key, [value | subtypes]),
     do: Enum.join([value | render_subtypes(subtypes)], "; ")
-
   defp render_header_value(key, value),
     do: render_header_value(key, List.wrap(value))
 
   defp validate_address(address) do
     case Regex.match?(@email_validation_regex, address) do
-      true ->
-        address
-
-      false ->
-        raise ArgumentError,
-          message: """
-          The email address `#{address}` is invalid.
-          """
+      true -> address
+      false -> raise ArgumentError,
+        message: """
+        The email address `#{address}` is invalid.
+        """
     end
   end
 
   defp render_address({name, email}), do: ~s("#{name}" <#{validate_address(email)}>)
   defp render_address(email), do: validate_address(email)
   defp render_subtypes([]), do: []
-
   defp render_subtypes([{key, value} | subtypes]) when is_atom(key),
     do: render_subtypes([{Atom.to_string(key), value} | subtypes])
 
   defp render_subtypes([{"boundary", value} | subtypes]) do
     [~s(boundary="#{value}") | render_subtypes(subtypes)]
   end
-
   defp render_subtypes([{key, value} | subtypes]) do
     key = String.replace(key, "_", "-")
     ["#{key}=#{value}" | render_subtypes(subtypes)]
@@ -143,10 +128,8 @@ defmodule Bamboo.SesAdapter.RFC2822WithBcc do
   Will render all headers according to the RFC2882 spec
   """
   def render_headers(headers)
-
   def render_headers(map) when is_map(map),
-    do: map |> Map.to_list() |> render_headers()
-
+    do: map |> Map.to_list |> render_headers()
   def render_headers(list) when is_list(list) do
     list
     |> do_render_headers()
@@ -172,15 +155,13 @@ defmodule Bamboo.SesAdapter.RFC2822WithBcc do
   end
 
   defp pad(num),
-    do:
-      num
-      |> Integer.to_string()
-      |> String.pad_leading(2, "0")
+    do: num
+        |> Integer.to_string()
+        |> String.pad_leading(2, "0")
 
   defp do_render_headers([]), do: []
   defp do_render_headers([{_key, nil} | headers]), do: do_render_headers(headers)
   defp do_render_headers([{_key, []} | headers]), do: do_render_headers(headers)
-
   defp do_render_headers([{key, value} | headers]) when is_binary(value) do
     if String.trim(value) == "" do
       do_render_headers(headers)
@@ -188,7 +169,6 @@ defmodule Bamboo.SesAdapter.RFC2822WithBcc do
       [render_header(key, value) | do_render_headers(headers)]
     end
   end
-
   defp do_render_headers([{key, value} | headers]) do
     [render_header(key, value) | do_render_headers(headers)]
   end
@@ -199,7 +179,7 @@ defmodule Bamboo.SesAdapter.RFC2822WithBcc do
     if Message.has_attachment?(message) do
       text_parts =
         message.parts
-        |> Enum.filter(&match_content_type?(&1, ~r/text\/(plain|html)/))
+        |> Enum.filter(&(match_content_type?(&1, ~r/text\/(plain|html)/)))
         |> Enum.sort(&(&1 > &2))
 
       content_type = List.replace_at(content_type, 0, "multipart/mixed")
@@ -208,16 +188,14 @@ defmodule Bamboo.SesAdapter.RFC2822WithBcc do
       if Enum.any?(text_parts) do
         message =
           text_parts
-          |> Enum.reduce(message, &Message.delete_part(&2, &1))
-
+          |> Enum.reduce(message, &(Message.delete_part(&2, &1)))
         mixed_part =
           Mail.build_multipart()
           |> Message.put_content_type("multipart/alternative")
 
         mixed_part =
           text_parts
-          |> Enum.reduce(mixed_part, &Message.put_part(&2, &1))
-
+          |> Enum.reduce(mixed_part, &(Message.put_part(&2, &1)))
         put_in(message.parts, List.insert_at(message.parts, 0, mixed_part))
       end
     else
@@ -225,7 +203,6 @@ defmodule Bamboo.SesAdapter.RFC2822WithBcc do
       Message.put_content_type(message, content_type)
     end
   end
-
   defp reorganize(%Message{} = message), do: message
 
   defp encode(body, message) do

--- a/lib/bamboo/adapters/ses_adapter.ex
+++ b/lib/bamboo/adapters/ses_adapter.ex
@@ -31,13 +31,17 @@ defmodule Bamboo.SesAdapter do
       |> Mail.put_subject(email.subject)
       |> Mail.put_text(email.text_body)
       |> Mail.put_html(email.html_body)
-    message = email.attachments
-              |> Enum.map(&prepare_file(&1))
-              |> Enum.reduce(message, &Mail.put_attachment(&2, &1))
+
+    message =
+      email.attachments
+      |> Enum.map(&prepare_file(&1))
+      |> Enum.reduce(message, &Mail.put_attachment(&2, &1))
+
     raw_message = Mail.render(message, RFC2822WithBcc)
 
     email = SES.send_raw_email(raw_message)
-    case email |> ExAws.request do
+
+    case email |> ExAws.request() do
       {:ok, response} -> response
       {:error, reason} -> raise_api_error(inspect(reason))
     end

--- a/lib/bamboo/adapters/ses_adapter.ex
+++ b/lib/bamboo/adapters/ses_adapter.ex
@@ -20,7 +20,7 @@ defmodule Bamboo.SesAdapter do
     config
   end
 
-  def deliver(email, _config) do
+  def deliver(email, config) do
     message =
       Mail.build_multipart()
       |> Mail.put_from(prepare_address(email.from))
@@ -41,7 +41,9 @@ defmodule Bamboo.SesAdapter do
 
     email = SES.send_raw_email(raw_message)
 
-    case email |> ExAws.request() do
+    ex_aws_config = Map.get(config, :ex_aws, [])
+
+    case email |> ExAws.request(ex_aws_config) do
       {:ok, response} -> response
       {:error, reason} -> raise_api_error(inspect(reason))
     end

--- a/mix.exs
+++ b/mix.exs
@@ -31,7 +31,7 @@ defmodule BambooSes.MixProject do
       {:mox, "~> 0.3", only: :test},
       {:credo, "~> 0.9.1", only: [:dev, :test], runtime: false},
       {:ex_doc, "~> 0.14", only: :dev},
-      {:inch_ex, ">= 0.0.0", only: :dev},
+      {:inch_ex, ">= 0.0.0", only: :dev}
     ]
   end
 
@@ -47,7 +47,7 @@ defmodule BambooSes.MixProject do
     [
       maintainers: ["Kalys Osmonov <kalys@osmonov.com>"],
       licenses: ["MIT"],
-      links: %{"GitHub" => "https://github.com/kalys/bamboo_ses"},
+      links: %{"GitHub" => "https://github.com/kalys/bamboo_ses"}
     ]
   end
 end

--- a/test/lib/bamboo/adapters/ses_adapter_test.exs
+++ b/test/lib/bamboo/adapters/ses_adapter_test.exs
@@ -92,6 +92,24 @@ defmodule Bamboo.SesAdapterTest do
     |> SesAdapter.deliver(%{})
   end
 
+  test "uses default aws region" do
+    expected_request_fn = fn _, "https://email.us-east-1.amazonaws.com/", _, _, _ ->
+      {:ok, %{status_code: 200}}
+    end
+
+    expect(HttpMock, :request, expected_request_fn)
+
+    new_email() |> SesAdapter.deliver(%{})
+  end
+
+  test "uses configured aws region" do
+    expect(HttpMock, :request, fn _, "https://email.eu-west-1.amazonaws.com/", _, _, _ ->
+      {:ok, %{status_code: 200}}
+    end)
+
+    new_email() |> SesAdapter.deliver(%{ex_aws: [region: "eu-west-1"]})
+  end
+
   test "raises error" do
     HttpMock
     |> expect(:request, fn _, _, _, _, _ -> {:ok, %{status_code: 404}} end)

--- a/test/lib/bamboo/adapters/ses_adapter_test.exs
+++ b/test/lib/bamboo/adapters/ses_adapter_test.exs
@@ -16,15 +16,16 @@ defmodule Bamboo.SesAdapterTest do
       headers: %{"Reply-To" => "chuck@example.com"},
       html_body: "<strong>Thanks for joining!</strong>",
       text_body: "Thanks for joining!"
-    ) |> Mailer.normalize_addresses()
+    )
+    |> Mailer.normalize_addresses()
   end
 
   defp parse_body(body) do
     body
-    |> URI.decode_query
+    |> URI.decode_query()
     |> Map.get("RawMessage.Data")
-    |> Base.decode64!
-    |> RFC2822.parse
+    |> Base.decode64!()
+    |> RFC2822.parse()
   end
 
   setup do
@@ -71,10 +72,13 @@ defmodule Bamboo.SesAdapterTest do
   test "delivers attachments" do
     expected_request_fn = fn _, _, body, _, _ ->
       message = parse_body(body)
-      filenames = message
-                  |> Mail.get_attachments
-                  |> Enum.map(&elem(&1, 0))
-                  |> Enum.sort
+
+      filenames =
+        message
+        |> Mail.get_attachments()
+        |> Enum.map(&elem(&1, 0))
+        |> Enum.sort()
+
       assert filenames == ["invoice.pdf", "song.mp3"]
       {:ok, %{status_code: 200}}
     end
@@ -83,9 +87,9 @@ defmodule Bamboo.SesAdapterTest do
     |> expect(:request, expected_request_fn)
 
     new_email()
-      |> Email.put_attachment(Path.join(__DIR__, "../../../support/invoice.pdf"))
-      |> Email.put_attachment(Path.join(__DIR__, "../../../support/song.mp3"))
-      |> SesAdapter.deliver(%{})
+    |> Email.put_attachment(Path.join(__DIR__, "../../../support/invoice.pdf"))
+    |> Email.put_attachment(Path.join(__DIR__, "../../../support/song.mp3"))
+    |> SesAdapter.deliver(%{})
   end
 
   test "raises error" do


### PR DESCRIPTION
Since SES is [not available in all regions](https://docs.aws.amazon.com/general/latest/gr/rande.html#ses_region), we would need to select a region to use SES different from our default one. This can be done by [passing a second argument to `ExAws.request/2`](https://hexdocs.pm/ex_aws/ExAws.html#request/2).