### PR TITLE
Handle empty body messages using mail v0.2.1

### DIFF
--- a/lib/bamboo/adapters/ses_adapter.ex
+++ b/lib/bamboo/adapters/ses_adapter.ex
@@ -29,8 +29,8 @@ defmodule Bamboo.SesAdapter do
       |> Mail.put_cc(prepare_addresses(email.cc))
       |> Mail.put_bcc(prepare_addresses(email.bcc))
       |> Mail.put_subject(email.subject)
-      |> Mail.put_text(email.text_body)
-      |> Mail.put_html(email.html_body)
+      |> put_text(email.text_body)
+      |> put_html(email.html_body)
     message = email.attachments
               |> Enum.map(&prepare_file(&1))
               |> Enum.reduce(message, &Mail.put_attachment(&2, &1))
@@ -46,6 +46,14 @@ defmodule Bamboo.SesAdapter do
   defp prepare_file(%Attachment{} = attachment) do
     {attachment.filename, attachment.data}
   end
+
+  def put_text(message, nil), do: message
+
+  def put_text(message, body), do: Mail.put_text(message, body)
+
+  def put_html(message, nil), do: message
+
+  def put_html(message, body), do: Mail.put_html(message, body)
 
   defp prepare_addresses(recipients) do
     recipients

--- a/mix.lock
+++ b/mix.lock
@@ -13,7 +13,7 @@
   "hackney": {:hex, :hackney, "1.12.1", "8bf2d0e11e722e533903fe126e14d6e7e94d9b7983ced595b75f532e04b7fdc7", [:rebar3], [{:certifi, "2.3.1", [hex: :certifi, optional: false]}, {:idna, "5.1.1", [hex: :idna, optional: false]}, {:metrics, "1.0.1", [hex: :metrics, optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, optional: false]}, {:ssl_verify_fun, "1.1.1", [hex: :ssl_verify_fun, optional: false]}]},
   "idna": {:hex, :idna, "5.1.1", "cbc3b2fa1645113267cc59c760bafa64b2ea0334635ef06dbac8801e42f7279c", [:rebar3], [{:unicode_util_compat, "0.3.1", [hex: :unicode_util_compat, optional: false]}]},
   "inch_ex": {:hex, :inch_ex, "0.5.6", "418357418a553baa6d04eccd1b44171936817db61f4c0840112b420b8e378e67", [:mix], [{:poison, "~> 1.5 or ~> 2.0 or ~> 3.0", [hex: :poison, optional: false]}]},
-  "mail": {:hex, :mail, "0.2.0", "4458b46fd097e4dd1b72f7ec578d35643d32c866ac5e0f154a068b377e5b3111", [:mix], []},
+  "mail": {:hex, :mail, "0.2.1", "65ba7cf79c07b79a3ce5946397a06b87d8b5f7e5f7b6d31ee8bcdfe940e27b86", [:mix], [], "hexpm"},
   "makeup": {:hex, :makeup, "0.5.1", "966c5c2296da272d42f1de178c1d135e432662eca795d6dc12e5e8787514edf7", [:mix], [{:nimble_parsec, "~> 0.2.2", [hex: :nimble_parsec, optional: false]}]},
   "makeup_elixir": {:hex, :makeup_elixir, "0.8.0", "1204a2f5b4f181775a0e456154830524cf2207cf4f9112215c05e0b76e4eca8b", [:mix], [{:makeup, "~> 0.5.0", [hex: :makeup, optional: false]}, {:nimble_parsec, "~> 0.2.2", [hex: :nimble_parsec, optional: false]}]},
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], []},

--- a/mix.lock
+++ b/mix.lock
@@ -1,10 +1,7 @@
 %{
   "bamboo": {:hex, :bamboo, "1.0.0", "446525f74eb59022ef58bc82f6c91c8e4c5a1469ab42a7f9b37c17262f872ef0", [:mix], [{:hackney, "~> 1.12.1", [hex: :hackney, optional: false]}, {:plug, "~> 1.0", [hex: :plug, optional: false]}, {:poison, ">= 1.5.0", [hex: :poison, optional: false]}]},
   "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], []},
-  "bypass": {:hex, :bypass, "0.8.1", "16d409e05530ece4a72fabcf021a3e5c7e15dcc77f911423196a0c551f2a15ca", [:mix], [{:cowboy, "~> 1.0", [hex: :cowboy, optional: false]}, {:plug, "~> 1.0", [hex: :plug, optional: false]}]},
   "certifi": {:hex, :certifi, "2.3.1", "d0f424232390bf47d82da8478022301c561cf6445b5b5fb6a84d49a9e76d2639", [:rebar3], [{:parse_trans, "3.2.0", [hex: :parse_trans, optional: false]}]},
-  "cowboy": {:hex, :cowboy, "1.1.2", "61ac29ea970389a88eca5a65601460162d370a70018afe6f949a29dca91f3bb0", [:rebar3], [{:cowlib, "~> 1.0.2", [hex: :cowlib, optional: false]}, {:ranch, "~> 1.3.2", [hex: :ranch, optional: false]}]},
-  "cowlib": {:hex, :cowlib, "1.0.2", "9d769a1d062c9c3ac753096f868ca121e2730b9a377de23dec0f7e08b1df84ee", [:make], []},
   "credo": {:hex, :credo, "0.9.3", "76fa3e9e497ab282e0cf64b98a624aa11da702854c52c82db1bf24e54ab7c97a", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, optional: false]}, {:poison, ">= 0.0.0", [hex: :poison, optional: false]}]},
   "earmark": {:hex, :earmark, "1.2.5", "4d21980d5d2862a2e13ec3c49ad9ad783ffc7ca5769cf6ff891a4553fbaae761", [:mix], []},
   "ex_aws": {:hex, :ex_aws, "2.1.0", "b92651527d6c09c479f9013caa9c7331f19cba38a650590d82ebf2c6c16a1d8a", [:mix], [{:configparser_ex, "~> 2.0", [hex: :configparser_ex, optional: true]}, {:hackney, "1.6.3 or 1.6.5 or 1.7.1 or 1.8.6 or ~> 1.9", [hex: :hackney, optional: true]}, {:jsx, "~> 2.8", [hex: :jsx, optional: true]}, {:poison, ">= 1.2.0", [hex: :poison, optional: true]}, {:sweet_xml, "~> 0.6", [hex: :sweet_xml, optional: true]}, {:xml_builder, "~> 0.1.0", [hex: :xml_builder, optional: true]}]},
@@ -24,7 +21,6 @@
   "parse_trans": {:hex, :parse_trans, "3.2.0", "2adfa4daf80c14dc36f522cf190eb5c4ee3e28008fc6394397c16f62a26258c2", [:rebar3], []},
   "plug": {:hex, :plug, "1.6.0", "90d338a44c8cd762c32d3ea324f6728445c6145b51895403854b77f1536f1617", [:mix], [{:cowboy, "~> 1.0.1 or ~> 1.1 or ~> 2.4", [hex: :cowboy, optional: true]}, {:mime, "~> 1.0", [hex: :mime, optional: false]}]},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], []},
-  "ranch": {:hex, :ranch, "1.3.2", "e4965a144dc9fbe70e5c077c65e73c57165416a901bd02ea899cfd95aa890986", [:rebar3], []},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:make, :rebar], []},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.3.1", "a1f612a7b512638634a603c8f401892afbf99b8ce93a45041f8aaca99cadb85e", [:rebar3], []},
 }

--- a/test/lib/bamboo/adapters/ses_adapter_test.exs
+++ b/test/lib/bamboo/adapters/ses_adapter_test.exs
@@ -54,6 +54,23 @@ defmodule Bamboo.SesAdapterTest do
     new_email() |> SesAdapter.deliver(%{})
   end
 
+  test "delivers successfully email withtout body" do
+    expected_request_fn = fn _, _, body, _, _ ->
+      message = parse_body(body)
+      assert Mail.get_text(message) == nil
+      assert Mail.get_html(message) == nil
+      assert Mail.get_from(message) == "bob@example.com"
+      assert Mail.get_to(message) == ["alice@example.com"]
+      {:ok, %{status_code: 200}}
+    end
+
+    expect(HttpMock, :request, expected_request_fn)
+
+    Email.new_email(from: "bob@example.com", to: "alice@example.com")
+    |> Mailer.normalize_addresses()
+    |> SesAdapter.deliver(%{})
+  end
+
   test "delivers mails with dashes in top level domain successfully" do
     expected_request_fn = fn _, _, body, _, _ ->
       message = parse_body(body)

--- a/test/lib/bamboo/adapters/ses_adapter_test.exs
+++ b/test/lib/bamboo/adapters/ses_adapter_test.exs
@@ -55,7 +55,7 @@ defmodule Bamboo.SesAdapterTest do
     new_email() |> SesAdapter.deliver(%{})
   end
 
-  test "delivers successfully email withtout body" do
+  test "delivers successfully email without body" do
     expected_request_fn = fn _, _, body, _, _ ->
       message = parse_body(body)
       assert Mail.get_text(message) == nil


### PR DESCRIPTION
Version 0.2.1 has [introduced a change](https://github.com/DockYard/elixir-mail/commit/89d05a88b5e8ab73a4a48c829356d98878a08b39) that doesn't allow `nil` as body massages anymore.