### PR TITLE
allow setting ses configuration set name

### DIFF
--- a/lib/bamboo/adapters/ses_adapter.ex
+++ b/lib/bamboo/adapters/ses_adapter.ex
@@ -33,7 +33,7 @@ defmodule Bamboo.SesAdapter do
          |> put_html(email.html_body)
          |> put_attachments(email.attachments)
          |> Mail.render(RFC2822WithBcc)
-         |> SES.send_raw_email()
+         |> SES.send_raw_email(configuration_set_name: email.private[:configuration_set_name])
          |> ExAws.request(ex_aws_config) do
       {:ok, response} -> response
       {:error, reason} -> raise_api_error(inspect(reason))
@@ -53,6 +53,12 @@ defmodule Bamboo.SesAdapter do
   def put_html(message, nil), do: message
 
   def put_html(message, body), do: Mail.put_html(message, body)
+
+  @doc """
+  Set the SES configuration set name.
+  """
+  def set_configuration_set(mail, configuration_set_name),
+    do: Bamboo.Email.put_private(mail, :configuration_set_name, configuration_set_name)
 
   defp prepare_addresses(recipients) do
     recipients

--- a/test/lib/bamboo/adapters/ses_adapter_test.exs
+++ b/test/lib/bamboo/adapters/ses_adapter_test.exs
@@ -109,6 +109,28 @@ defmodule Bamboo.SesAdapterTest do
     |> SesAdapter.deliver(%{})
   end
 
+  test "sets the configuration set" do
+    expected_configuration_set_name = "some-configuration-set"
+
+    expected_request_fn = fn _, _, body, _, _ ->
+      configuration_set_name =
+        body
+        |> URI.decode_query()
+        |> Map.get("ConfigurationSetName")
+
+      assert configuration_set_name == expected_configuration_set_name
+
+      {:ok, %{status_code: 200}}
+    end
+
+    HttpMock
+    |> expect(:request, expected_request_fn)
+
+    new_email()
+    |> SesAdapter.set_configuration_set(expected_configuration_set_name)
+    |> SesAdapter.deliver(%{})
+  end
+
   test "uses default aws region" do
     expected_request_fn = fn _, "https://email.us-east-1.amazonaws.com/", _, _, _ ->
       {:ok, %{status_code: 200}}


### PR DESCRIPTION
This allows setting the configuration set name, which is neccessary to publish SES events to Firehose, for example.