### PR TITLE
Punycode email domains, encode addresses with RFC1342

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ erl_crash.dump
 bamboo_ses-*.tar
 
 .env
+.elixir_ls/

--- a/test/lib/bamboo/adapters/ses_adapter_test.exs
+++ b/test/lib/bamboo/adapters/ses_adapter_test.exs
@@ -33,6 +33,7 @@ defmodule Bamboo.SesAdapterTest do
     System.put_env("AWS_SECRET_ACCESS_KEY", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY")
     Application.put_env(:ex_aws, :http_client, ExAws.Request.HttpMock)
     Application.put_env(:bamboo_ses, :rfc1342, false)
+    Application.put_env(:bamboo_ses, :punycode, false)
     :ok
   end
 
@@ -192,7 +193,8 @@ defmodule Bamboo.SesAdapterTest do
       assert Mail.get_bcc(message) == "=?utf-8?B?SmFuZSBEb2U=?= <jane@example.com>"
       assert Mail.get_reply_to(message) == {"=?utf-8?B?Q2h1Y2sgRWFnZXI=?=", "chuck@example.com"}
 
-      assert Mail.get_subject(message) == "=?utf-8?B?V2VsY29tZSB0byB0aGUgYXBwIHRoaXMgaXMgYSBsb25nZXIgcw==?= =?utf-8?B?dWJqZWN0?="
+      assert Mail.get_subject(message) ==
+               "=?utf-8?B?V2VsY29tZSB0byB0aGUgYXBwIHRoaXMgaXMgYSBsb25nZXIgcw==?= =?utf-8?B?dWJqZWN0?="
 
       {:ok, %{status_code: 200}}
     end
@@ -201,5 +203,29 @@ defmodule Bamboo.SesAdapterTest do
 
     SesAdapter.deliver(email, %{})
     Application.put_env(:bamboo_ses, :rfc1342, false)
+  end
+
+  test "punycode" do
+    Application.put_env(:bamboo_ses, :punycode, true)
+
+    email =
+      Email.new_email(
+        to: {"Alice Johnson", "alice@möhren.de"},
+        cc: "bob@rüben.de",
+        from: "someone@example.com"
+      )
+      |> Mailer.normalize_addresses()
+
+    expected_request_fn = fn _, _, body, _, _ ->
+      message = parse_body(body)
+      assert Mail.get_to(message) == [{"Alice Johnson", "alice@xn--mhren-jua.de"}]
+      assert Mail.get_cc(message) == "bob@xn--rben-0ra.de"
+
+      {:ok, %{status_code: 200}}
+    end
+
+    expect(HttpMock, :request, expected_request_fn)
+
+    SesAdapter.deliver(email, %{})
   end
 end

--- a/test/lib/bamboo/adapters/ses_adapter_test.exs
+++ b/test/lib/bamboo/adapters/ses_adapter_test.exs
@@ -32,6 +32,7 @@ defmodule Bamboo.SesAdapterTest do
     System.put_env("AWS_ACCESS_KEY_ID", "AKIAIOSFODNN7EXAMPLE")
     System.put_env("AWS_SECRET_ACCESS_KEY", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY")
     Application.put_env(:ex_aws, :http_client, ExAws.Request.HttpMock)
+    Application.put_env(:bamboo_ses, :rfc1342, false)
     :ok
   end
 
@@ -167,5 +168,38 @@ defmodule Bamboo.SesAdapterTest do
     assert_raise(ApiError, fn ->
       SesAdapter.deliver(new_email(), %{})
     end)
+  end
+
+  test "rfc1342" do
+    Application.put_env(:bamboo_ses, :rfc1342, true)
+
+    email =
+      Email.new_email(
+        to: {"Alice Johnson", "alice@example.com"},
+        from: {"Bob McBob", "bob@example.com"},
+        headers: %{"Reply-To" => {"Chuck Eager", "chuck@example.com"}},
+        cc: {"John Müller", "john@example.com"},
+        bcc: {"Jane Doe", "jane@example.com"},
+        subject: "Welcome to the app this is a longer subject"
+      )
+      |> Mailer.normalize_addresses()
+
+    expected_request_fn = fn _, _, body, _, _ ->
+      message = parse_body(body)
+      assert Mail.get_to(message) == [{"=?utf-8?B?QWxpY2UgSm9obnNvbg==?=", "alice@example.com"}]
+      assert Mail.get_from(message) == {"=?utf-8?B?Qm9iIE1jQm9i?=", "bob@example.com"}
+      assert Mail.get_cc(message) == "=?utf-8?B?Sm9obiBNw7xsbGVy?= <john@example.com>"
+      assert Mail.get_bcc(message) == "=?utf-8?B?SmFuZSBEb2U=?= <jane@example.com>"
+      assert Mail.get_reply_to(message) == {"=?utf-8?B?Q2h1Y2sgRWFnZXI=?=", "chuck@example.com"}
+
+      assert Mail.get_subject(message) == "=?utf-8?B?V2VsY29tZSB0byB0aGUgYXBwIHRoaXMgaXMgYSBsb25nZXIgcw==?= =?utf-8?B?dWJqZWN0?="
+
+      {:ok, %{status_code: 200}}
+    end
+
+    expect(HttpMock, :request, expected_request_fn)
+
+    SesAdapter.deliver(email, %{})
+    Application.put_env(:bamboo_ses, :rfc1342, false)
   end
 end


### PR DESCRIPTION
We recently switched from another provider to SES, only to discover that the former provider was transparently rewriting email headers and subjects to make them work with non-ascii chars.

This PR allows bamboo_ses to optionally rewrite addresses and the subject to use RFC1342 encoding, and to use punycode for the domain part of email addresses.

Note that this does not include docs changes.