### PR TITLE
Remove template query when not given

### DIFF
--- a/test/lib/bamboo/adapters/ses_adapter_test.exs
+++ b/test/lib/bamboo/adapters/ses_adapter_test.exs
@@ -110,12 +110,10 @@ defmodule Bamboo.SesAdapterTest do
     expected_configuration_set_name = "some-configuration-set"
 
     expected_request_fn = fn _, _, body, _, _ ->
-      configuration_set_name =
-        body
-        |> URI.decode_query()
-        |> Map.get("ConfigurationSetName")
-
-      assert configuration_set_name == expected_configuration_set_name
+      query = URI.decode_query(body)
+      assert query["ConfigurationSetName"] == expected_configuration_set_name
+      refute Map.has_key?(query, "Template")
+      refute Map.has_key?(query, "TemplateData")
       {:ok, %{status_code: 200}}
     end
 


### PR DESCRIPTION
When the query has empty `Template` and `TemplateData` some mails are sent successfully, but some mails fail.
I'm not sure, but the template seems to be a problem, so I removed it when not in use.

related #20 