### PR TITLE
Handle double-quotes in addresses

### DIFF
--- a/lib/bamboo/adapters/ses_adapter.ex
+++ b/lib/bamboo/adapters/ses_adapter.ex
@@ -30,7 +30,7 @@ defmodule Bamboo.SesAdapter do
          |> Mail.put_to(prepare_addresses(email.to))
          |> Mail.put_cc(prepare_addresses(email.cc))
          |> Mail.put_bcc(prepare_addresses(email.bcc))
-         |> Mail.put_subject(q_encode(email.subject))
+         |> Mail.put_subject(maybe_rfc1342_encode(email.subject))
          |> put_headers(email.headers)
          |> put_text(email.text_body)
          |> put_html(email.html_body)
@@ -107,20 +107,70 @@ defmodule Bamboo.SesAdapter do
   defp prepare_address({"", address}), do: encode_address(address)
 
   defp prepare_address({name, address}) do
-    name = name |> String.replace("\"", "\\\"") |> q_encode()
-    {name, encode_address(address)}
+    {maybe_rfc1342_encode(name), encode_address(address)}
   end
-
-  defp q_encode(string) when is_binary(string) do
-    q_encoded = String.replace(Mail.Encoders.QuotedPrintable.encode(string), "=\r\n", "")
-
-    "=?utf-8?Q?#{q_encoded}?="
-  end
-
-  defp q_encode(string), do: string
 
   defp encode_address(address) do
     [local_part, domain_part] = String.split(address, "@")
     Enum.join([Mail.Encoders.SevenBit.encode(local_part), :idna.utf8_to_ascii(domain_part)], "@")
+  end
+
+  defp maybe_rfc1342_encode(string) when is_binary(string) do
+    should_encode? = !ascii?(string) || String.contains?(string, ["\"", "?"])
+
+    if should_encode? do
+      rfc1342_encode(string)
+    else
+      string
+    end
+  end
+
+  defp maybe_rfc1342_encode(_), do: nil
+
+  defp rfc1342_encode(string) when is_binary(string) do
+    rfc1342_encode(string, [])
+  end
+
+  defp rfc1342_encode(_), do: nil
+
+  def rfc1342_encode("", acc), do: acc |> Enum.reverse() |> Enum.join(" ")
+
+  def rfc1342_encode(string, acc) do
+    # https://tools.ietf.org/html/rfc1342
+    # > An encoded-word may not be more than 75 characters long, including
+    # > charset, encoding, encoded-text, and delimiters.  If it is desirable
+    # > to encode more text than will fit in an encoded-word of 75
+    # > characters, multiple encoded-words (separated by SPACE or newline)
+    # > may be used.
+    maximum_possible_text_length =
+      rfc1342_maximum_encoded_word_length() - String.length(encode_word(""))
+
+    {encoded, rest} =
+      maximum_possible_text_length..1
+      |> Enum.reduce_while(nil, fn n, _ ->
+        {word, rest} = String.split_at(string, n)
+        encoded = encode_word(word)
+
+        if String.length(encoded) <= rfc1342_maximum_encoded_word_length() do
+          {:halt, {encoded, rest}}
+        else
+          {:cont, nil}
+        end
+      end)
+
+    rfc1342_encode(rest, [encoded | acc])
+  end
+
+  defp ascii?(string) do
+    non_ascii_chars = Enum.uniq(String.codepoints(string)) -- Enum.map(0..127, fn x -> <<x>> end)
+    Enum.empty?(non_ascii_chars)
+  end
+
+  defp rfc1342_maximum_encoded_word_length do
+    75
+  end
+
+  defp encode_word(word) do
+    "=?utf-8?B?#{Base.encode64(word)}?="
   end
 end

--- a/lib/bamboo/adapters/ses_adapter.ex
+++ b/lib/bamboo/adapters/ses_adapter.ex
@@ -106,8 +106,10 @@ defmodule Bamboo.SesAdapter do
   defp prepare_address({nil, address}), do: encode_address(address)
   defp prepare_address({"", address}), do: encode_address(address)
 
-  defp prepare_address({name, address}),
-    do: {q_encode(name), encode_address(address)}
+  defp prepare_address({name, address}) do
+    name = name |> String.replace("\"", "\\\"") |> q_encode()
+    {name, encode_address(address)}
+  end
 
   defp q_encode(string) when is_binary(string) do
     q_encoded = String.replace(Mail.Encoders.QuotedPrintable.encode(string), "=\r\n", "")


### PR DESCRIPTION
## Problem

If I try to send an email from, for example, `{"publication \"name\" ;)", "foo@example.com"}`, the email will include this line:

```
From: "=?utf-8?Q?publication "name" ;)?=" <foo@example.com>
```

The unescaped double-quotes cause parsing errors. This is how such an email looks in my mail client:

<img width="420" alt="Screen Shot 2021-02-01 at 16 10 04" src="https://user-images.githubusercontent.com/7852553/106477897-ee495a00-64a8-11eb-8b1e-129962f00520.png">

Even worse, if there is only a single double-quote in the name, or there is a comma between the double-quotes, the email is not parsable at all and the SES API rejects it.

## Solution

This PR attempts to solve this issue by escaping `"` as `\"`.

In https://tools.ietf.org/html/rfc2822#section-3.2.5, it says:

> Also note that since quoted-pair
   is allowed in a quoted-string, the quote and backslash characters may
   appear in a quoted-string so long as they appear as a quoted-pair.

And a `quoted-pair` is defined here https://tools.ietf.org/html/rfc2822#section-3.2.2 as `("\" text)`, and hence my conclusion that `"` needs escaping as `\"`.