### PR TITLE
Update ses_adapter.ex

### DIFF
--- a/lib/bamboo/adapters/ses_adapter.ex
+++ b/lib/bamboo/adapters/ses_adapter.ex
@@ -88,7 +88,7 @@ defmodule Bamboo.SesAdapter do
   defp put_text(message, nil), do: message
 
   defp put_text(message, body) do
-    if ascii_only(body) do
+    if ascii?(body) do
       Mail.put_text(message, body)
     else
       Mail.put_text(message, body, charset: "UTF-8")
@@ -98,7 +98,7 @@ defmodule Bamboo.SesAdapter do
   defp put_html(message, nil), do: message
 
   defp put_html(message, body) do
-    if ascii_only(body) do
+    if ascii?(body) do
       Mail.put_html(message, body)
     else
       Mail.put_html(message, body, charset: "UTF-8")


### PR DESCRIPTION
The latest PR had a small typo that this fixes. 

It's important to have the UTF-8 charset option for emails as emoji turn into Chinese characters without it.