### PR TITLE
Feature/tag upgrade

### DIFF
--- a/lib/bamboo/adapters/ses_adapter.ex
+++ b/lib/bamboo/adapters/ses_adapter.ex
@@ -28,9 +28,7 @@ defmodule Bamboo.SesAdapter do
     opts = for {opt, value} when value != nil <- opts,
       do: {opt, value}
 
-    template = email.private[:template]
-    template_data = email.private[:template_data]
-    send_email(email, opts, template, template_data)
+    send_email(email, opts)
     |> ExAws.request(ex_aws_config)
     |> case do
       {:ok, response} -> {:ok, response}
@@ -38,7 +36,7 @@ defmodule Bamboo.SesAdapter do
     end
   end
 
-  defp send_email(email, opts, nil, nil) do
+  defp send_email(email, opts) do
     Mail.build_multipart()
     |> Mail.put_from(prepare_address(email.from))
     |> Mail.put_to(prepare_addresses(email.to))
@@ -51,16 +49,6 @@ defmodule Bamboo.SesAdapter do
     |> put_attachments(email.attachments)
     |> Mail.render(RFC2822Renderer)
     |> SES.send_raw_email(opts)
-  end
-
-  defp send_email(email, opts, template, data) do
-    to = %{
-      to: prepare_addresses(email.to),
-      cc: prepare_addresses(email.cc),
-      bcc: prepare_addresses(email.bcc)
-    }
-    from = prepare_address(email.from)
-    SES.send_templated_email(to, from, template, data, opts)
   end
 
   defp put_headers(message, headers) when is_map(headers),

--- a/mix.exs
+++ b/mix.exs
@@ -25,10 +25,10 @@ defmodule BambooSes.MixProject do
 
   defp deps do
     [
+      {:idna, "~>6.1.1"},
       {:ex_aws_ses, "~> 2.3.0"},
       {:bamboo, "~> 2.0"},
       {:mail, "~> 0.2.0"},
-      {:jason, "~> 1.1"},
       {:mox, "~> 1.0", only: :test},
       {:credo, "~> 1.4", only: [:dev, :test], runtime: false},
       {:ex_doc, ">= 0.0.0", only: :dev, runtime: false}


### PR DESCRIPTION
Hi @kalys ,

I needed the ability to add tags to an email, and it seems this feature is available upstream on `:ex_aws_ses`.  To use the feature required extracting `:tags` from the private dictionary contained in `Bamboo.Email`, and then passing it to `:ex_aws_ses`.  It also required an update to the `:ex_aws_ses` library, which entailed a change to how templated emails are passed - that is, it now uses an explicit function.

I made the requisite changes, which pass the tests, and also added a new test to demonstrate passing tags.  The templating function inside `:ex_aws_ses` handles  json pre-encoding of the data, so I was also able to remove `Jason` from the dependencies.

All things considered, the patch is very minor.  Let me know what you think.  It would be good to see this hit upstream on git

Cheers,

Jarrod