### PR TITLE
FIX double encoded mail subject

### DIFF
--- a/lib/bamboo/adapters/message/content.ex
+++ b/lib/bamboo/adapters/message/content.ex
@@ -85,7 +85,7 @@ defmodule BambooSes.Message.Content do
   defp build_content(_template_params, subject, text, html, headers, attachments) do
     raw_data =
       Mail.build_multipart()
-      |> Mail.put_subject(Encoding.maybe_rfc1342_encode(subject))
+      |> Mail.put_subject(subject)
       |> put_raw_text(text)
       |> put_raw_html(html)
       |> put_headers(headers)

--- a/test/lib/bamboo/adapters/content_raw_test.exs
+++ b/test/lib/bamboo/adapters/content_raw_test.exs
@@ -69,11 +69,11 @@ defmodule BambooSes.ContentRawTest do
   end
 
   test "delivers successfully with long subject" do
+    subject =
+      "This is a long subject with an emoji 🙂 bla bla bla bla bla bla bla bla bla bla bla bla bla bla bla bla"
+
     content =
-      TestHelpers.new_email(
-        "alice@example.com",
-        "This is a long subject with an emoji 🙂 bla bla bla bla bla bla bla bla bla bla bla bla bla bla bla bla"
-      )
+      TestHelpers.new_email("alice@example.com", subject)
       |> Email.put_attachment(Path.join(__DIR__, "../../../support/invoice.pdf"))
       |> Content.build_from_bamboo_email()
 
@@ -83,12 +83,11 @@ defmodule BambooSes.ContentRawTest do
       }
     } = content
 
-    subject =
+    parsed_subject =
       raw_data
       |> EmailParser.parse()
       |> EmailParser.subject()
 
-    assert subject ==
-             "=?utf-8?B?#{Base.encode64("This is a long subject with an emoji 🙂 bla")}?= =?utf-8?B?#{Base.encode64(" bla bla bla bla bla bla bla bla bla bla bla ")}?= =?utf-8?B?#{Base.encode64("bla bla bla bla")}?="
+    assert parsed_subject == subject
   end
 end


### PR DESCRIPTION
Hello @kalys!

We were having an issue with the adapter, when sending emails with attachments, the subject was being wrongly encoded.

example: 
<img width="732" alt="image" src="https://user-images.githubusercontent.com/14171790/214413446-1169a01f-91b4-4287-bd15-d29c6331b61d.png">


What we found out was that we were using especial characters in the subject like `¡Tu cuenta está lista!` and that was causing the issue of calling the `Encoding.maybe_rfc1342_encode`. but we found out that was being doubled encoded.

After modifying code and tested in our environment we managed to solve it.
<img width="762" alt="image" src="https://user-images.githubusercontent.com/14171790/214416899-c2608844-5d8b-4429-8ea5-09093c933a1c.png">


Regards!