### PR TITLE
Allow newer versions of ex_aws

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -28,7 +28,7 @@ defmodule BambooSes.MixProject do
 
   defp deps do
     [
-      {:ex_aws, "~> 2.4.1"},
+      {:ex_aws, "~> 2.4"},
       {:bamboo, "~> 2.0"},
       {:gen_smtp, "~> 1.2.0"},
       {:jason, "~> 1.1"},


### PR DESCRIPTION
ex_aws is now releasing 2.5 versions. I was unable to upgrade because the current version spec doesn't allow upgrading beyond 2.4.x

I've changed it so any 2.x.x version beyond 2.4 is acceptable. This allows apps to upgrade to newer versions, but does not force it.