### PR TITLE
Encode strings with backslashes in email name part

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -14,11 +14,11 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Setup elixir
-      uses: actions/setup-elixir@v1
+      id: setup-beam
+      uses: erlef/setup-beam@v1
       with:
         elixir-version: 1.14.x # Define the elixir version [required]
         otp-version: 25.x # Define the OTP version [required]
-        experimental-otp: true
     - name: Install Dependencies
       run: mix deps.get
     - name: Run Tests
@@ -32,9 +32,9 @@ jobs:
       id: plt_cache
       with:
         key: |
-          ${{ runner.os }}-${{ steps.beam.outputs.elixir-version }}-${{ steps.beam.outputs.otp-version }}-plt
+          ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ steps.setup-beam.outputs.otp-version }}-plt
         restore-keys: |
-          ${{ runner.os }}-${{ steps.beam.outputs.elixir-version }}-${{ steps.beam.outputs.otp-version }}-plt
+          ${{ runner.os }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ steps.setup-beam.outputs.otp-version }}-plt
         path: |
           priv/plts
 

--- a/lib/bamboo/adapters/message/encoding.ex
+++ b/lib/bamboo/adapters/message/encoding.ex
@@ -29,7 +29,7 @@ defmodule BambooSes.Encoding do
   """
   @spec maybe_rfc1342_encode(String.t()) :: String.t()
   def maybe_rfc1342_encode(string) when is_binary(string) do
-    should_encode? = not ascii?(string) || String.contains?(string, ["\"", "?"])
+    should_encode? = not ascii?(string) || String.contains?(string, ["\"", "?", "\\"])
 
     if should_encode? do
       rfc1342_encode(string)

--- a/test/lib/bamboo/adapters/encoding_test.exs
+++ b/test/lib/bamboo/adapters/encoding_test.exs
@@ -25,8 +25,12 @@ defmodule BambooSes.EncodingTest do
   end
 
   test "encodes special symbols" do
-    assert Encoding.prepare_address({"Chuck (?) Eager", "chuck@example.com"}) ==
-             ~s("=?utf-8?B?#{Base.encode64("Chuck (?) Eager")}?=" <chuck@example.com>)
+    for sym <- ["\"", "?", "\\"],
+        do:
+          assert(
+            Encoding.prepare_address({"Chuck (#{sym}) Eager", "chuck@example.com"}) ==
+              ~s("=?utf-8?B?#{Base.encode64("Chuck (#{sym}) Eager")}?=" <chuck@example.com>)
+          )
   end
 
   test "encodes emojis" do


### PR DESCRIPTION
Also encodes friendly name in email addresses when they contain backslashes (SES chokes otherwise)

~Note that for some reason the build is failing in the Elixir setup action, haven't had time to investigate.~

Edit: NVM, Github workflow is fixed now