### PR TITLE
Lessen gen_smtp dependency

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -30,7 +30,7 @@ defmodule BambooSes.MixProject do
     [
       {:ex_aws, "~> 2.4"},
       {:bamboo, "~> 2.0"},
-      {:gen_smtp, "~> 1.2.0"},
+      {:gen_smtp, "~> 1.2"},
       {:jason, "~> 1.1"},
       {:mox, "~> 1.0", only: :test},
       {:eiconv, ">= 0.0.0", only: :test, runtime: false},


### PR DESCRIPTION
gen_smtp 1.2 is not compatible with Erlang 28+, it was updated in 1.3 for compatibility.

Please lessen the dependency if possible 🙂